### PR TITLE
Fix tag name completion in Valheim 0.217.24

### DIFF
--- a/BetterPortal/BetterPortal.csproj
+++ b/BetterPortal/BetterPortal.csproj
@@ -193,6 +193,10 @@
             <SpecificVersion>False</SpecificVersion>
             <HintPath>$(ManagedDataDirectory)\assembly_utils.dll</HintPath>
         </Reference>
+        <Reference Include="ui_lib">
+            <SpecificVersion>False</SpecificVersion>
+            <HintPath>$(ManagedDataDirectory)\ui_lib.dll</HintPath>
+        </Reference>
     </ItemGroup>
     <ItemGroup>
         <Compile Include="**\*.cs" Exclude="bin\**\*;obj\**\*;Libraries\**\*" />

--- a/BetterPortal/Patches.cs
+++ b/BetterPortal/Patches.cs
@@ -156,8 +156,7 @@ namespace BetterPortal
             TextReceiver ___m_queuedSign, bool ___m_visibleFrame)
         {
             if (!___m_visibleFrame || Console.IsVisible() || Chat.instance.HasFocus()) return;
-            if ((!__instance.m_textField || !__instance.m_textField.isFocused) &&
-                (!__instance.m_textFieldTMP || !__instance.m_textFieldTMP.isFocused)) return;
+            if ((!__instance.m_inputField || !__instance.m_inputField.isFocused)) return;
             if (!TeleportWorldExtension.GetAllInstance()
                     .Any(x => ReferenceEquals(x, ___m_queuedSign))) return;
 

--- a/BetterPortal/TextInputExtension.cs
+++ b/BetterPortal/TextInputExtension.cs
@@ -24,17 +24,9 @@ namespace BetterPortal
 
         private static void UpdateTextInput(TextInput input, string text)
         {
-            if (input.m_textField)
+            if (input.m_inputField)
             {
-                var textField = input.m_textField;
-                if (text == textField.text) return;
-
-                textField.text = string.IsNullOrEmpty(text) ? "" : text;
-                textField.MoveTextEnd(false);
-            }
-            else if (input.m_textFieldTMP)
-            {
-                var textField = input.m_textFieldTMP;
+                var textField = input.m_inputField;
                 if (text == textField.text) return;
 
                 textField.text = string.IsNullOrEmpty(text) ? "" : text;
@@ -77,8 +69,7 @@ namespace BetterPortal
 
             if (!_keyPressed || _keyHold) return;
 
-            var text = (input.m_textField ? input.m_textField.text : input.m_textFieldTMP.text) ??
-                       "";
+            var text = (input.m_inputField ? input.m_inputField.text : "");
             if (_pressedKey == KeyCode.Insert)
                 UpdateTextInput(input, AutoComplete(text));
             else if (_pressedKey == KeyCode.UpArrow || _pressedKey == KeyCode.DownArrow)


### PR DESCRIPTION
`TextInput` no longer has `m_textField` and `m_textFieldTMP`, they have been replaced by a single `m_inputField`.